### PR TITLE
Add documentation of design phases

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,8 @@ Affinity Gateway, under the API tab.
 
 Endpoints are documented by the [Affinity API specification](http://apidocs.affinitygateway.com/).
 
+A list of "phases," or review states, for designs, are documented [here](design-phases.md).
+
 ## Webhooks
 
 [Webhook documentation is located here](webhooks.md).

--- a/docs/design-phases.md
+++ b/docs/design-phases.md
@@ -1,0 +1,42 @@
+# Design Phases
+
+- On Hold
+    - ID: 1
+    - Group: On Hold (Group ID 5)
+    - Description: This design is awaiting a response from a third party before completing review.
+- Pending Licensor Review
+    - ID: 2
+    - Group: Licensor Review (Group ID 3)
+    - Description: This design is awaiting review by the licensor.
+- Pending Admin Review
+    - ID: 3
+    - Group: In Review (Group ID 2)
+    - Description: This design is awaiting review by Affinity staff.
+- Rejected By Licensor
+    - ID: 7
+    - Group: Rejected (Group ID 4)
+    - Description: This design was rejected by the licensor.
+- Rejected By Admin
+    - ID: 8
+    - Group: Rejected (Group ID 4)
+    - Description: This design was rejected by Affinity staff.
+- Final Rejected By Admin
+    - ID: 9
+    - Group: Rejected (Group ID 4)
+    - Description: This design was rejected by Affinity staff, and may not be resubmitted in any form.
+- Approved By Admin With Changes
+    - ID: 12
+    - Group: Approved (Group ID 1)
+    - Description: This design was approved by Affinity staff, given that the specified changes were made.
+- Approved By Licensor With Changes
+    - ID: 13
+    - Group: Approved (Group ID 1)
+    - Description: This design was approved by the licensor, given that the specified changes were made.
+- Approved By Admin
+    - ID: 14
+    - Group: Approved (Group ID 1)
+    - Description: This design was approved by Affinity staff.
+- Approved By Licensor
+    - ID: 15
+    - Group: Approved (Group ID 1)
+    - Description: This design was approved by the licensor.


### PR DESCRIPTION
Add a list of design phases to the affinity-api-docs project.
This may be better served as an endpoint, but in the midst of moving
endpoints to the gateway this should be fine for now.

https://app.clubhouse.io/affinitylicensing/story/3299/add-design-phases-to-api-docs